### PR TITLE
tox.ini: Use standard py3* targets for CPython up to 3.6 + PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - pypy
 
 install:
     - "pip install sphinx"

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,11 @@
 [tox]
-envlist=py26,py27,py3,py3.1,py3.2,py3.3,py2.7-docs,py3.3-docs
+envlist=py26,py27,py31,py32,py33,py34,py35,py36,pypy,py2.7-docs,py3.3-docs
 
 [testenv]
 commands=python test/test.py
 
-[testenv:py26]
-basepython=python2.6
-
-[testenv:py27]
-basepython=python2.7
-
-[testenv:py3]
-basepython=python3
-
-[testenv:py3.1]
+[testenv:py31]
 basepython=python3.1
-
-[testenv:py3.2]
-basepython=python3.2
-
-[testenv:py3.3]
-basepython=python3.3
-
-[testenv:py3.4]
-basepython=python3.4
 
 [testenv:py2.7-docs]
 basepython=python2.7


### PR DESCRIPTION
Replace the custom 'py3.x' environments with standard tox 'py3x',
and remove the redundant 'py3' environment. Remove unnecessary
'basepython' declarations whenever tox derives them correctly. Add new
environments for Python versions up to the latest 3.6 release. Also
add a PyPy target.