### PR TITLE
Automatically upload Windows binary wheels

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,85 @@
+environment:
+  TWINE_USERNAME: bauerj
+  # The encrypted password, used for deploying.
+  TWINE_PASSWORD: 
+    secure: nJvSXE3tRtnBNSmQNZ0oZg==
+
+  matrix:
+
+    # Pre-installed Python versions, which Appveyor may upgrade to
+    # a later point release.
+
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python36"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_ARCH: "64"
+
+init:
+  - "ECHO Python %PYTHON_VERSION% (%PYTHON_ARCH%bit) from %PYTHON%"
+
+install:
+  - ECHO "Filesystem root:"
+  - ps: "ls \"C:/\""
+
+  - ECHO "Installed SDKs:"
+  - ps: "ls \"C:/Program Files/Microsoft SDKs/Windows\""
+
+  # Update Python PATH of this build (so pip is available, this cannot be
+  # done from inside the powershell script as it would require to restart
+  # the parent CMD process).
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - "python --version"
+
+  # Upgrade to the latest version of pip to avoid it displaying warnings
+  # about it being out of date.
+  - "pip install --disable-pip-version-check --user --upgrade pip"
+
+  # Install twine, support for 'bdist_wheel' and update setuptools.
+  - "pip install --upgrade wheel setuptools twine"
+
+build_script:
+  - "python setup.py install"
+
+test_script:
+  # Build the compiled extension and run the project tests
+  - "python test/test.py"
+
+after_test:
+  # If tests are successful, create binary packages for the project.
+  - "python setup.py bdist_wheel"
+  - ps: "ls dist"
+
+artifacts:
+  # Archive the generated packages in the ci.appveyor.com build report.
+  - path: dist\*.whl
+
+on_success:
+  # If this is a new release (a new tag), upload to PyPi
+  - if "%APPVEYOR_REPO_TAG%"=="true" ( twine upload dist\*.whl )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ Hash objects from this module follow the API of standard library's
 `hashlib` objects.
 """
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 # Version of optimized implementation to use.
 


### PR DESCRIPTION
Since it's quite a hassle to compile the packages from source (especially on Windows) it's generally a good idea to supply binary wheels in addition to the source packages.

This will automatically upload wheels to PyPi whenever a new tag is uploaded 🚀 

To use this, some initial configuration is needed:
1. Login with your Github account on https://www.appveyor.com/
2. Enable CI for pyblake2
3. Change the user environment variables in `appveyor.yml` in the repository.
    -  `TWINE_USERNAME` should be a PyPi user with access to the `pyblake2` project.
    - `TWINE_PASSWORD` should be the **encrypted** password for that user. To encrypt it, you can use [this](https://ci.appveyor.com/tools/encrypt) AppVeyor tool.


Secure variables (like `TWINE_PASSWORD`) will not be decrypted for pull requests so there is not risk of it being leaked to malicious users.

Closes: #9 
Related: spesmilo/electrum#3871