### PR TITLE
Support for PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.5"
     - "3.6"
     - pypy
+    - pypy3
 
 install:
     - "pip install sphinx"

--- a/pyblake2module.c
+++ b/pyblake2module.c
@@ -121,11 +121,7 @@ getbuffer(PyObject *obj, Py_buffer *bp) {
 static void
 tohex(char *dst, uint8_t *src, size_t srclen)
 {
-#if PY_VERSION_HEX >= 0x03030000
-# define hexdigits Py_hexdigits
-#else
     static char hexdigits[] = "0123456789abcdef";
-#endif
     size_t i;
 
     for (i = 0; i < srclen; i++) {

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py31,py32,py33,py34,py35,py36,pypy,py2.7-docs,py3.3-docs
+envlist=py26,py27,py31,py32,py33,py34,py35,py36,pypy,pypy3,py2.7-docs,py3.3-docs
 
 [testenv]
 commands=python test/test.py


### PR DESCRIPTION
This fixes one issue (probably-private constant use) that breaks build with PyPy3 and enables testing for it.